### PR TITLE
Deprecate and replace PayloadInterface status constants

### DIFF
--- a/src/PayloadInterface.php
+++ b/src/PayloadInterface.php
@@ -6,28 +6,88 @@ interface PayloadInterface
 {
     /**
      * @var integer All good.
+     * @deprecated 1.1.0
+     * @see \Equip\Adr\PayloadInterface::STATUS_OK
      */
     const OK = 10;
 
     /**
      * @var integer Error during domain processing.
+     * @deprecated 1.1.0
      */
     const ERROR = 20;
 
     /**
      * @var integer Invalid domain input.
+     * @deprecated 1.1.0
      */
     const INVALID = 30;
 
     /**
      * @var integer Unknown domain state.
+     * @deprecated 1.1.0
      */
     const UNKNOWN = 40;
 
     /**
+     * @var string
+     */
+    const STATUS_OK = 'OK';
+
+    /**
+     * @var string
+     */
+    const STATUS_CREATED = 'Created';
+
+    /**
+     * @var string
+     */
+    const STATUS_ACCEPTED = 'Accepted';
+
+    /**
+     * @var string
+     */
+    const STATUS_NO_CONTENT = 'No Content';
+
+    /**
+     * @var string
+     */
+    const STATUS_MOVED_PERMANENTLY = 'Moved Permanently';
+
+    /**
+     * @var string
+     */
+    const STATUS_FOUND = 'Found';
+
+    /**
+     * @var string
+     */
+    const STATUS_NOT_MODIFIED = 'Not Modified';
+
+    /**
+     * @var string
+     */
+    const STATUS_BAD_REQUEST = 'Bad Request';
+
+    /**
+     * @var string
+     */
+    const STATUS_UNAUTHORIZED = 'Unauthorized';
+
+    /**
+     * @var string
+     */
+    const STATUS_FORBIDDEN = 'Forbidden';
+
+    /**
+     * @var string
+     */
+    const STATUS_NOT_FOUND = 'Not Found';
+
+    /**
      * Create a copy of the payload with the status.
      *
-     * @param int $status
+     * @param string $status
      * @return PayloadInterface
      */
     public function withStatus($status);
@@ -35,7 +95,7 @@ interface PayloadInterface
     /**
      * Get the status of the payload.
      *
-     * @return int
+     * @return string
      */
     public function getStatus();
 


### PR DESCRIPTION
I limited the codes included to the ones we're likely to use most often. Feel free to suggest others. Here's [a more comprehensive list of them](https://github.com/lukasoppermann/http-status/blob/master/src/Httpstatuscodes.php).
