### PR TITLE
Add payload settings to interface

### DIFF
--- a/src/PayloadInterface.php
+++ b/src/PayloadInterface.php
@@ -71,4 +71,39 @@ interface PayloadInterface extends Status
      * @return array
      */
     public function getMessages();
+
+    /**
+     * Create a copy of the payload with a modified setting.
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function withSetting($name, $value);
+
+    /**
+     * Create a copy of the payload without a setting.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function withoutSetting($name);
+
+    /**
+     * Get a payload setting.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getSetting($name);
+
+    /**
+     * Get all payload settings.
+     *
+     * @return array
+     */
+    public function getSettings();
 }


### PR DESCRIPTION
All current payload methods are meant to deal with public output.
There are some situations where having internal settings are also
valuable. For example, creating a redirect in a payload to another
action or defining template name.

Refs equip/framework#40
